### PR TITLE
Make `createIntInRange` work for full int range

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "random"
-version = "1.5.0"
+version = "1.5.1"
 authors = ["Ballerina"]
 keywords = ["pseudo-random"]
 repository = "https://github.com/ballerina-platform/module-ballerina-random"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -27,7 +27,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "random"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"},

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -1,3 +1,4 @@
+import ballerina/jballerina.java;
 // Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
@@ -13,9 +14,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/time;
-import ballerina/jballerina.java;
 
 const decimal a = 25214903917;
 const decimal c = 17;

--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -45,7 +45,7 @@ public isolated function createIntInRange(int startRange, int endRange) returns 
     if startRange > endRange {
         return error Error("End range value must be greater than the start range value");
     }
-    return <int>(lcg() / m * <decimal>(endRange - startRange - 1) + <decimal>startRange);
+    return <int>(lcg() / m * (<decimal>(endRange - 1) - <decimal>startRange) + <decimal>startRange);
 }
 
 isolated function lcg() returns decimal {

--- a/ballerina/tests/random.bal
+++ b/ballerina/tests/random.bal
@@ -13,7 +13,6 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-
 import ballerina/test;
 
 @test:Config {}
@@ -37,7 +36,7 @@ isolated function negativeTestforCreateIntInRangeTest() {
     int|error result = createIntInRange(5000, 10);
     if result is error {
         test:assertTrue(result.message().includes("End range value must be greater than the start range value"),
-                     msg = "negativeTestforCreateIntInRangeTest result incorrect");
+                    msg = "negativeTestforCreateIntInRangeTest result incorrect");
     } else {
         test:assertFail("Result is not mismatch");
     }
@@ -48,7 +47,7 @@ isolated function doesNotThrowForFullIntRangeTest() {
     int|error result = createIntInRange(int:MIN_VALUE, int:MAX_VALUE);
     if result is int {
         test:assertTrue(result >= int:MIN_VALUE && result < int:MAX_VALUE,
-                     msg = "createIntInRangeTest result is not within 5 and 10");
+                    msg = "createIntInRangeTest result is not within 5 and 10");
     } else {
         test:assertFail("createIntInRangeTest result is not int");
     }
@@ -56,10 +55,10 @@ isolated function doesNotThrowForFullIntRangeTest() {
 
 @test:Config {}
 isolated function doesNotThrowForAlmostFullIntRangeRTest() {
-    int|error result = createIntInRange(int:MIN_VALUE+1, int:MAX_VALUE);
+    int|error result = createIntInRange(int:MIN_VALUE + 1, int:MAX_VALUE);
     if result is int {
-        test:assertTrue(result >= int:MIN_VALUE+1 && result < int:MAX_VALUE,
-                     msg = "createIntInRangeTest result is not within 5 and 10");
+        test:assertTrue(result >= int:MIN_VALUE + 1 && result < int:MAX_VALUE,
+                    msg = "createIntInRangeTest result is not within 5 and 10");
     } else {
         test:assertFail("createIntInRangeTest result is not int");
     }
@@ -67,10 +66,10 @@ isolated function doesNotThrowForAlmostFullIntRangeRTest() {
 
 @test:Config {}
 isolated function doesNotThrowForAlmostFullIntRangeLTest() {
-    int|error result = createIntInRange(int:MIN_VALUE, int:MAX_VALUE-1);
+    int|error result = createIntInRange(int:MIN_VALUE, int:MAX_VALUE - 1);
     if result is int {
-        test:assertTrue(result >= int:MIN_VALUE && result < int:MAX_VALUE-1,
-                     msg = "createIntInRangeTest result is not within 5 and 10");
+        test:assertTrue(result >= int:MIN_VALUE && result < int:MAX_VALUE - 1,
+                    msg = "createIntInRangeTest result is not within 5 and 10");
     } else {
         test:assertFail("createIntInRangeTest result is not int");
     }

--- a/ballerina/tests/random.bal
+++ b/ballerina/tests/random.bal
@@ -42,3 +42,36 @@ isolated function negativeTestforCreateIntInRangeTest() {
         test:assertFail("Result is not mismatch");
     }
 }
+
+@test:Config {}
+isolated function doesNotThrowForFullIntRangeTest() {
+    int|error result = createIntInRange(int:MIN_VALUE, int:MAX_VALUE);
+    if result is int {
+        test:assertTrue(result >= int:MIN_VALUE && result < int:MAX_VALUE,
+                     msg = "createIntInRangeTest result is not within 5 and 10");
+    } else {
+        test:assertFail("createIntInRangeTest result is not int");
+    }
+}
+
+@test:Config {}
+isolated function doesNotThrowForAlmostFullIntRangeRTest() {
+    int|error result = createIntInRange(int:MIN_VALUE+1, int:MAX_VALUE);
+    if result is int {
+        test:assertTrue(result >= int:MIN_VALUE+1 && result < int:MAX_VALUE,
+                     msg = "createIntInRangeTest result is not within 5 and 10");
+    } else {
+        test:assertFail("createIntInRangeTest result is not int");
+    }
+}
+
+@test:Config {}
+isolated function doesNotThrowForAlmostFullIntRangeLTest() {
+    int|error result = createIntInRange(int:MIN_VALUE, int:MAX_VALUE-1);
+    if result is int {
+        test:assertTrue(result >= int:MIN_VALUE && result < int:MAX_VALUE-1,
+                     msg = "createIntInRangeTest result is not within 5 and 10");
+    } else {
+        test:assertFail("createIntInRangeTest result is not int");
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 
 ### Changed
 - [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
+- [Make `createIntInRange` work for full int range ](https://github.com/ballerina-platform/ballerina-standard-library/issues/4744)
 
 ## [1.3.0] - 2022-05-30
 


### PR DESCRIPTION
## Purpose

Closes ballerina-platform/ballerina-standard-library#4744

## Examples

The code like
```ballerina
random:createIntInRange(int:MIN_VALUE, int:MAX_VALUE);
```

no longer causes `int range overflow` error.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility

## Other remarks for reviewers
- I will be grateful about any remarks regarding code formatting and organization of the tests,
- while working on this I have found a _small_ bug, cf. ballerina-platform/ballerina-standard-library#4892