### PR TITLE
Prohibit calling `createIntInRange` with empty range

### DIFF
--- a/ballerina/natives.bal
+++ b/ballerina/natives.bal
@@ -41,7 +41,7 @@ public isolated function createDecimal() returns float {
 # + endRange - Range end value
 # + return - Selected random value or else, a `random:Error` if the start range is greater than the end range
 public isolated function createIntInRange(int startRange, int endRange) returns int|Error {
-    if startRange > endRange {
+    if startRange >= endRange {
         return error Error("End range value must be greater than the start range value");
     }
     return <int>(lcg() / m * (<decimal>(endRange - 1) - <decimal>startRange) + <decimal>startRange);

--- a/ballerina/tests/random.bal
+++ b/ballerina/tests/random.bal
@@ -32,11 +32,33 @@ isolated function createIntInRangeTest() {
 }
 
 @test:Config {}
+isolated function createIntInRangeWithSingleElementTest() {
+    final int someInt = 123;
+    int|error result = createIntInRange(someInt, someInt + 1);
+    if result is int {
+        test:assertTrue(result == someInt, msg = "createIntInRangeWithSingleElementTest result is not " + someInt.toString());
+    } else {
+        test:assertFail("createIntInRangeTest result is not int");
+    }
+}
+
+@test:Config {}
 isolated function negativeTestforCreateIntInRangeTest() {
     int|error result = createIntInRange(5000, 10);
     if result is error {
         test:assertTrue(result.message().includes("End range value must be greater than the start range value"),
                     msg = "negativeTestforCreateIntInRangeTest result incorrect");
+    } else {
+        test:assertFail("Result is not mismatch");
+    }
+}
+
+@test:Config {}
+isolated function negativeTestforCreateIntInRange2Test() {
+    int|error result = createIntInRange(17, 17);
+    if result is error {
+        test:assertTrue(result.message().includes("End range value must be greater than the start range value"),
+                    msg = "negativeTestforCreateIntInRange2Test result incorrect");
     } else {
         test:assertFail("Result is not mismatch");
     }

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ This file contains all the notable changes done to the Ballerina TCP package thr
 ### Changed
 
 - [Make `createIntInRange` work for full int range ](https://github.com/ballerina-platform/ballerina-standard-library/issues/4744)
+- [Prohibit calling `createIntInRange` with empty range](https://github.com/ballerina-platform/ballerina-standard-library/issues/4892)
 
 ## [1.5.0] - 2023-09-15
 


### PR DESCRIPTION
## Purpose
Closes ballerina-platform/ballerina-standard-library#4892.

## Examples
The call like

```ballerina
createIntInRange(10, 10);
```

is no longer valid.

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
